### PR TITLE
Update to nanos SDK 2.0

### DIFF
--- a/src/oxen_blind.c
+++ b/src/oxen_blind.c
@@ -37,7 +37,7 @@ int monero_apdu_blind() {
     monero_io_discard(1);
 
     if ((G_oxen_state.options & 0x03) == 2) {
-        os_memset(k, 0, 32);
+        memset(k, 0, 32);
         monero_ecdhHash(AKout, AKout);
         for (int i = 0; i < 8; i++) {
             v[i] = v[i] ^ AKout[i];

--- a/src/oxen_clsag.c
+++ b/src/oxen_clsag.c
@@ -111,7 +111,7 @@ int monero_apdu_clsag_hash() {
         oxen_hash_final(&G_oxen_state.keccak_alt, c);
         monero_reduce(c);
         monero_io_insert(c, 32);
-        os_memmove(G_oxen_state.clsag_c, c, 32);
+        memmove(G_oxen_state.clsag_c, c, 32);
     }
     return SW_OK;
 }

--- a/src/oxen_crypto.c
+++ b/src/oxen_crypto.c
@@ -304,7 +304,7 @@ void monero_ge_fromfe_frombytes(unsigned char *ge, const unsigned char *bytes) {
     cx_math_multm(v, u, u, MOD); /* 2 * u^2 */
     cx_math_addm(v, v, v, MOD);
 
-    os_memset(w, 0, 32);
+    memset(w, 0, 32);
     w[31] = 1;                                           /* w = 1 */
     cx_math_addm(w, v, w, MOD);                          /* w = 2 * u^2 + 1 */
     cx_math_multm(x, w, w, MOD);                         /* w^2 */
@@ -328,7 +328,7 @@ void monero_ge_fromfe_frombytes(unsigned char *ge, const unsigned char *bytes) {
     cx_math_multm(y, rX, rX, MOD);
     cx_math_multm(x, y, x, MOD);
     cx_math_subm(y, w, x, MOD);
-    os_memmove(z, C_fe_ma, 32);
+    memmove(z, C_fe_ma, 32);
 
     if (!cx_math_is_zero(y, 32)) {
         cx_math_addm(y, w, x, MOD);
@@ -373,8 +373,8 @@ setsign:
     Pxy[0] = 0x04;
     cx_math_multm(&Pxy[1], rX, u, MOD);
     cx_math_multm(&Pxy[1 + 32], rY, u, MOD);
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
-    os_memmove(ge, &Pxy[1], 32);
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(ge, &Pxy[1], 32);
 
 #undef u
 #undef v
@@ -620,10 +620,10 @@ void monero_ecmul_G(unsigned char *W, const unsigned char *scalar32) {
     unsigned char Pxy[65];
     unsigned char s[32];
     monero_reverse32(s, scalar32);
-    os_memmove(Pxy, C_ED25519_G, 65);
+    memmove(Pxy, C_ED25519_G, 65);
     cx_ecfp_scalar_mult(CX_CURVE_Ed25519, Pxy, sizeof(Pxy), s, 32);
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
-    os_memmove(W, &Pxy[1], 32);
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(W, &Pxy[1], 32);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -636,13 +636,13 @@ void monero_ecmul_H(unsigned char *W, const unsigned char *scalar32) {
     monero_reverse32(s, scalar32);
 
     Pxy[0] = 0x02;
-    os_memmove(&Pxy[1], C_ED25519_Hy, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(&Pxy[1], C_ED25519_Hy, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
 
     cx_ecfp_scalar_mult(CX_CURVE_Ed25519, Pxy, sizeof(Pxy), s, 32);
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
 
-    os_memmove(W, &Pxy[1], 32);
+    memmove(W, &Pxy[1], 32);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -655,13 +655,13 @@ void monero_ecmul_k(unsigned char *W, const unsigned char *P, const unsigned cha
     monero_reverse32(s, scalar32);
 
     Pxy[0] = 0x02;
-    os_memmove(&Pxy[1], P, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(&Pxy[1], P, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
 
     cx_ecfp_scalar_mult(CX_CURVE_Ed25519, Pxy, sizeof(Pxy), s, 32);
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
 
-    os_memmove(W, &Pxy[1], 32);
+    memmove(W, &Pxy[1], 32);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -671,13 +671,13 @@ void monero_ecmul_8(unsigned char *W, const unsigned char *P) {
     unsigned char Pxy[65];
 
     Pxy[0] = 0x02;
-    os_memmove(&Pxy[1], P, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(&Pxy[1], P, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
     cx_ecfp_add_point(CX_CURVE_Ed25519, Pxy, Pxy, Pxy, sizeof(Pxy));
     cx_ecfp_add_point(CX_CURVE_Ed25519, Pxy, Pxy, Pxy, sizeof(Pxy));
     cx_ecfp_add_point(CX_CURVE_Ed25519, Pxy, Pxy, Pxy, sizeof(Pxy));
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
-    os_memmove(W, &Pxy[1], 32);
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(W, &Pxy[1], 32);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -688,17 +688,17 @@ void monero_ecadd(unsigned char *W, const unsigned char *P, const unsigned char 
     unsigned char Qxy[65];
 
     Pxy[0] = 0x02;
-    os_memmove(&Pxy[1], P, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(&Pxy[1], P, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
 
     Qxy[0] = 0x02;
-    os_memmove(&Qxy[1], Q, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Qxy, sizeof(Qxy));
+    memmove(&Qxy[1], Q, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Qxy, sizeof(Qxy));
 
     cx_ecfp_add_point(CX_CURVE_Ed25519, Pxy, Pxy, Qxy, sizeof(Pxy));
 
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
-    os_memmove(W, &Pxy[1], 32);
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(W, &Pxy[1], 32);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -709,18 +709,18 @@ void monero_ecsub(unsigned char *W, const unsigned char *P, const unsigned char 
     unsigned char Qxy[65];
 
     Pxy[0] = 0x02;
-    os_memmove(&Pxy[1], P, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(&Pxy[1], P, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
 
     Qxy[0] = 0x02;
-    os_memmove(&Qxy[1], Q, 32);
-    cx_edward_decompress_point(CX_CURVE_Ed25519, Qxy, sizeof(Qxy));
+    memmove(&Qxy[1], Q, 32);
+    cx_edwards_decompress_point(CX_CURVE_Ed25519, Qxy, sizeof(Qxy));
 
     cx_math_sub(Qxy + 1, (unsigned char *)C_ED25519_FIELD, Qxy + 1, 32);
     cx_ecfp_add_point(CX_CURVE_Ed25519, Pxy, Pxy, Qxy, sizeof(Pxy));
 
-    cx_edward_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
-    os_memmove(W, &Pxy[1], 32);
+    cx_edwards_compress_point(CX_CURVE_Ed25519, Pxy, sizeof(Pxy));
+    memmove(W, &Pxy[1], 32);
 }
 
 /* ----------------------------------------------------------------------- */
@@ -807,6 +807,6 @@ void monero_rng_mod_order(unsigned char *r) {
 uint64_t monero_bamount2uint64(unsigned char *binary) {
     // Value is already little endian, so just copy it directly from the bytes:
     uint64_t xmr;
-    os_memmove(&xmr, binary, 8);
+    memmove(&xmr, binary, 8);
     return xmr;
 }

--- a/src/oxen_init.c
+++ b/src/oxen_init.c
@@ -39,10 +39,10 @@ const unsigned char C_FAKE_SEC_SPEND_KEY[32] = {
 /* --- Boot                                                            --- */
 /* ----------------------------------------------------------------------- */
 void monero_init(void) {
-    os_memset(&G_oxen_state, 0, sizeof(oxen_v_state_t));
+    memset(&G_oxen_state, 0, sizeof(oxen_v_state_t));
 
     // first init ?
-    if (os_memcmp((void*)N_oxen_state->magic, (void*)C_MAGIC, sizeof(C_MAGIC)) != 0) {
+    if (memcmp((void*)N_oxen_state->magic, (void*)C_MAGIC, sizeof(C_MAGIC)) != 0) {
 #if defined(OXEN_ALPHA) || defined(OXEN_BETA)
         oxen_install(TESTNET);
 #else
@@ -65,8 +65,8 @@ void monero_init(void) {
 /* --- init private keys                                               --- */
 /* ----------------------------------------------------------------------- */
 void monero_wipe_private_key(void) {
-    os_memset(G_oxen_state.keys, 0, sizeof(G_oxen_state.keys));
-    os_memset(&G_oxen_state.spk, 0, sizeof(G_oxen_state.spk));
+    memset(G_oxen_state.keys, 0, sizeof(G_oxen_state.keys));
+    memset(&G_oxen_state.spk, 0, sizeof(G_oxen_state.spk));
     G_oxen_state.key_set = 0;
 }
 
@@ -96,8 +96,8 @@ void monero_init_private_key(void) {
             break;
 
         case KEY_MODE_EXTERNAL:
-            os_memmove(G_oxen_state.view_priv, (void*)N_oxen_state->view_priv, 32);
-            os_memmove(G_oxen_state.spend_priv, (void*)N_oxen_state->spend_priv, 32);
+            memmove(G_oxen_state.view_priv, (void*)N_oxen_state->view_priv, 32);
+            memmove(G_oxen_state.spend_priv, (void*)N_oxen_state->spend_priv, 32);
             break;
 
         default:
@@ -120,10 +120,10 @@ void monero_init_ux(void) {
     unsigned char wallet_len = oxen_wallet_address(
             G_oxen_state.ux_address, G_oxen_state.view_pub, G_oxen_state.spend_pub, 0, NULL);
 
-    os_memmove(G_oxen_state.ux_wallet_public_short_address, G_oxen_state.ux_address, 7);
+    memmove(G_oxen_state.ux_wallet_public_short_address, G_oxen_state.ux_address, 7);
     G_oxen_state.ux_wallet_public_short_address[7] = '.';
     G_oxen_state.ux_wallet_public_short_address[8] = '.';
-    os_memmove(G_oxen_state.ux_wallet_public_short_address + 9,
+    memmove(G_oxen_state.ux_wallet_public_short_address + 9,
                G_oxen_state.ux_address + wallet_len - 3, 3);
     G_oxen_state.ux_wallet_public_short_address[12] = 0;
 }
@@ -178,7 +178,7 @@ int monero_apdu_reset(void) {
     for (i = 0; i < OXEN_SUPPORTED_CLIENT_SIZE; i++) {
         size_t len = strlen((char*)PIC(oxen_supported_client[i]));
         if (len <= client_version_len &&
-                os_memcmp((char*)PIC(oxen_supported_client[i]), client_version, len) == 0) {
+                memcmp((char*)PIC(oxen_supported_client[i]), client_version, len) == 0) {
             break;
         }
     }

--- a/src/oxen_io.c
+++ b/src/oxen_io.c
@@ -62,7 +62,7 @@ void monero_io_discard(int clear) {
     }
 }
 
-void monero_io_clear(void) { os_memset(G_oxen_state.io_buffer, 0, MONERO_IO_BUFFER_LENGTH); }
+void monero_io_clear(void) { memset(G_oxen_state.io_buffer, 0, MONERO_IO_BUFFER_LENGTH); }
 
 /* ----------------------------------------------------------------------- */
 /* INSERT data to be sent                                                  */
@@ -72,7 +72,7 @@ void monero_io_hole(unsigned int sz) {
     if ((G_oxen_state.io_length + sz) > MONERO_IO_BUFFER_LENGTH) {
         THROW(ERROR_IO_FULL);
     }
-    os_memmove(G_oxen_state.io_buffer + G_oxen_state.io_offset + sz,
+    memmove(G_oxen_state.io_buffer + G_oxen_state.io_offset + sz,
                G_oxen_state.io_buffer + G_oxen_state.io_offset,
                G_oxen_state.io_length - G_oxen_state.io_offset);
     G_oxen_state.io_length += sz;
@@ -80,7 +80,7 @@ void monero_io_hole(unsigned int sz) {
 
 void monero_io_insert(unsigned char const* buff, unsigned int len) {
     monero_io_hole(len);
-    os_memmove(G_oxen_state.io_buffer + G_oxen_state.io_offset, buff, len);
+    memmove(G_oxen_state.io_buffer + G_oxen_state.io_offset, buff, len);
     G_oxen_state.io_offset += len;
 }
 
@@ -92,7 +92,7 @@ void monero_io_insert_hmac_for(unsigned char* buffer, int len, int type) {
 
     unsigned char hmac[32 + 1 + 4];
 
-    os_memmove(hmac, buffer, 32);
+    memmove(hmac, buffer, 32);
     hmac[32] = type;
     if (type == TYPE_ALPHA) {
         hmac[33] = (G_oxen_state.tx_sign_cnt >> 0) & 0xFF;
@@ -122,7 +122,7 @@ void monero_io_insert_encrypt(unsigned char* buffer, int len, int type) {
         G_oxen_state.io_buffer[G_oxen_state.io_offset + i] = buffer[i] ^ 0x55;
     }
 #elif defined(IONOCRYPT)
-    os_memmove(G_oxen_state.io_buffer + G_oxen_state.io_offset, buffer, len);
+    memmove(G_oxen_state.io_buffer + G_oxen_state.io_offset, buffer, len);
 #else
     cx_aes(&G_oxen_state.spk, CX_ENCRYPT | CX_CHAIN_CBC | CX_LAST | CX_PAD_NONE, buffer, len,
            G_oxen_state.io_buffer + G_oxen_state.io_offset, len);
@@ -177,7 +177,7 @@ void monero_io_assert_available(int sz) {
 int monero_io_fetch(unsigned char* buffer, int len) {
     monero_io_assert_available(len);
     if (buffer) {
-        os_memmove(buffer, G_oxen_state.io_buffer + G_oxen_state.io_offset, len);
+        memmove(buffer, G_oxen_state.io_buffer + G_oxen_state.io_offset, len);
     }
     G_oxen_state.io_offset += len;
     return len;
@@ -191,7 +191,7 @@ static void monero_io_verify_hmac_for(const unsigned char* buffer, int len,
     }
 
     unsigned char hmac[37];
-    os_memmove(hmac, buffer, 32);
+    memmove(hmac, buffer, 32);
     hmac[32] = type;
     if (type == TYPE_ALPHA) {
         hmac[33] = (G_oxen_state.tx_sign_cnt >> 0) & 0xFF;
@@ -205,7 +205,7 @@ static void monero_io_verify_hmac_for(const unsigned char* buffer, int len,
         hmac[36] = 0;
     }
     cx_hmac_sha256(G_oxen_state.hmac_key, 32, hmac, 37, hmac, 32);
-    if (os_memcmp(hmac, expected_hmac, 32)) {
+    if (memcmp(hmac, expected_hmac, 32)) {
         monero_lock_and_throw(SW_SECURITY_HMAC);
     }
 }
@@ -231,7 +231,7 @@ int monero_io_fetch_decrypt(unsigned char* buffer, int len, int type) {
             buffer[i] = G_oxen_state.io_buffer[G_oxen_state.io_offset + i] ^ 0x55;
         }
 #elif defined(IONOCRYPT)
-        os_memmove(buffer, G_oxen_state.io_buffer + G_oxen_state.io_offset, len);
+        memmove(buffer, G_oxen_state.io_buffer + G_oxen_state.io_offset, len);
 #else  // IOCRYPT
         cx_aes(&G_oxen_state.spk, CX_DECRYPT | CX_CHAIN_CBC | CX_LAST | CX_PAD_NONE,
                G_oxen_state.io_buffer + G_oxen_state.io_offset, len, buffer, len);
@@ -264,7 +264,7 @@ int monero_io_fetch_decrypt_key(unsigned char* buffer) {
 
     k = G_oxen_state.io_buffer + G_oxen_state.io_offset;
     // view?
-    if (os_memcmp(k, C_FAKE_SEC_VIEW_KEY, 32) == 0) {
+    if (memcmp(k, C_FAKE_SEC_VIEW_KEY, 32) == 0) {
         G_oxen_state.io_offset += 32;
         if (G_oxen_state.tx_in_progress) {
             monero_io_assert_available(32);
@@ -273,11 +273,11 @@ int monero_io_fetch_decrypt_key(unsigned char* buffer) {
                                       TYPE_SCALAR);
             G_oxen_state.io_offset += 32;
         }
-        os_memmove(buffer, G_oxen_state.view_priv, 32);
+        memmove(buffer, G_oxen_state.view_priv, 32);
         return 32;
     }
     // spend?
-    else if (os_memcmp(k, C_FAKE_SEC_SPEND_KEY, 32) == 0) {
+    else if (memcmp(k, C_FAKE_SEC_SPEND_KEY, 32) == 0) {
         switch (G_oxen_state.io_ins) {
             case INS_VERIFY_KEY:
             case INS_DERIVE_SECRET_KEY:
@@ -293,7 +293,7 @@ int monero_io_fetch_decrypt_key(unsigned char* buffer) {
                                       G_oxen_state.io_buffer + G_oxen_state.io_offset,
                                       TYPE_SCALAR);
         }
-        os_memmove(buffer, G_oxen_state.spend_priv, 32);
+        memmove(buffer, G_oxen_state.spend_priv, 32);
         return 32;
     }
     // else
@@ -376,7 +376,7 @@ int monero_io_do(unsigned int io_flags) {
         if (G_oxen_state.io_length > MONERO_APDU_LENGTH) {
             THROW(SW_IO_FULL);
         }
-        os_memmove(G_io_apdu_buffer, G_oxen_state.io_buffer + G_oxen_state.io_offset,
+        memmove(G_io_apdu_buffer, G_oxen_state.io_buffer + G_oxen_state.io_offset,
                    G_oxen_state.io_length);
 
         if (io_flags & IO_RETURN_AFTER_TX) {
@@ -397,7 +397,7 @@ int monero_io_do(unsigned int io_flags) {
     G_oxen_state.io_lc = 0;
     G_oxen_state.io_le = 0;
     G_oxen_state.io_lc = G_io_apdu_buffer[4];
-    os_memmove(G_oxen_state.io_buffer, G_io_apdu_buffer + 5, G_oxen_state.io_lc);
+    memmove(G_oxen_state.io_buffer, G_io_apdu_buffer + 5, G_oxen_state.io_lc);
     G_oxen_state.io_length = G_oxen_state.io_lc;
 
     return 0;

--- a/src/oxen_key.c
+++ b/src/oxen_key.c
@@ -54,8 +54,8 @@ int monero_apdu_display_address(void) {
     if (minor | major) {
         monero_get_subaddress(C, D, index);
     } else {
-        os_memmove(C, G_oxen_state.view_pub, 32);
-        os_memmove(D, G_oxen_state.spend_pub, 32);
+        memmove(C, G_oxen_state.view_pub, 32);
+        memmove(D, G_oxen_state.spend_pub, 32);
     }
 
     // prepare UI
@@ -80,9 +80,9 @@ int monero_apdu_display_address(void) {
 /* ----------------------------------------------------------------------- */
 /* ---                                                                 --- */
 /* ----------------------------------------------------------------------- */
-int is_fake_view_key(const unsigned char *s) { return os_memcmp(s, C_FAKE_SEC_VIEW_KEY, 32) == 0; }
+int is_fake_view_key(const unsigned char *s) { return memcmp(s, C_FAKE_SEC_VIEW_KEY, 32) == 0; }
 
-int is_fake_spend_key(const unsigned char *s) { return os_memcmp(s, C_FAKE_SEC_SPEND_KEY, 32) == 0; }
+int is_fake_spend_key(const unsigned char *s) { return memcmp(s, C_FAKE_SEC_SPEND_KEY, 32) == 0; }
 
 /* ----------------------------------------------------------------------- */
 /* ---                                                                 --- */
@@ -102,7 +102,7 @@ int monero_apdu_put_key(void) {
     monero_io_fetch(sec, 32);
     monero_io_fetch(pub, 32);
     monero_ecmul_G(raw, sec);
-    if (os_memcmp(pub, raw, 32)) {
+    if (memcmp(pub, raw, 32)) {
         THROW(SW_WRONG_DATA);
         return SW_WRONG_DATA;
     }
@@ -112,7 +112,7 @@ int monero_apdu_put_key(void) {
     monero_io_fetch(sec, 32);
     monero_io_fetch(pub, 32);
     monero_ecmul_G(raw, sec);
-    if (os_memcmp(pub, raw, 32)) {
+    if (memcmp(pub, raw, 32)) {
         THROW(SW_WRONG_DATA);
         return SW_WRONG_DATA;
     }
@@ -222,15 +222,15 @@ int monero_apdu_verify_key(void) {
             monero_secret_key_to_public_key(computed_pub, priv);
             break;
         case 1:
-            os_memmove(computed_pub, G_oxen_state.view_pub, 32);
+            memmove(computed_pub, G_oxen_state.view_pub, 32);
             break;
         case 2:
-            os_memmove(computed_pub, G_oxen_state.spend_pub, 32);
+            memmove(computed_pub, G_oxen_state.spend_pub, 32);
             break;
         default:
             THROW(SW_WRONG_P1P2);
     }
-    if (os_memcmp(computed_pub, pub, 32) == 0) {
+    if (memcmp(computed_pub, pub, 32) == 0) {
         verified = 1;
     }
 
@@ -248,8 +248,8 @@ int monero_apdu_get_chacha8_prekey(/*char  *prekey*/) {
     unsigned char pre[32];
 
     monero_io_discard(0);
-    os_memmove(abt, G_oxen_state.view_priv, 32);
-    os_memmove(abt + 32, G_oxen_state.spend_priv, 32);
+    memmove(abt, G_oxen_state.view_priv, 32);
+    memmove(abt + 32, G_oxen_state.spend_priv, 32);
     abt[64] = CHACHA8_KEY_TAIL;
     oxen_keccak_256(&G_oxen_state.keccak, abt, 65, pre);
     monero_io_insert((unsigned char *)G_oxen_state.keccak.acc, 200);
@@ -274,8 +274,8 @@ int monero_apdu_sc_add(/*unsigned char *r, unsigned char *s1, unsigned char *s2*
         // https://github.com/monero-project/monero/blob/v0.15.0.5/src/cryptonote_basic/cryptonote_format_utils.cpp#L331
         //
         //      hwdev.sc_secret_add(scalar_step2, scalar_step1,subaddr_sk);
-        if ((os_memcmp(s1, G_oxen_state.last_derive_secret_key, 32) != 0) ||
-            (os_memcmp(s2, G_oxen_state.last_get_subaddress_secret_key, 32) != 0)) {
+        if ((memcmp(s1, G_oxen_state.last_derive_secret_key, 32) != 0) ||
+            (memcmp(s2, G_oxen_state.last_get_subaddress_secret_key, 32) != 0)) {
             monero_lock_and_throw(SW_WRONG_DATA);
         }
     }
@@ -431,7 +431,7 @@ int monero_apdu_derive_secret_key(/*const crypto::key_derivation &derivation, co
     monero_derive_secret_key(drvsec, derivation, output_index, sec);
 
     // sec key
-    os_memmove(G_oxen_state.last_derive_secret_key, drvsec, 32);
+    memmove(G_oxen_state.last_derive_secret_key, drvsec, 32);
     monero_io_insert_encrypt(drvsec, 32, TYPE_SCALAR);
     return SW_OK;
 }
@@ -579,9 +579,9 @@ int oxen_apdu_generate_lns_signature(void) {
     monero_io_fetch(subaddr_index, 8);
     monero_io_discard(1);
 
-    if (os_memcmp(subaddr_index, "\0\0\0\0\0\0\0\0", 8) == 0) {
-        os_memmove(SKEY, G_oxen_state.spend_priv, 32);
-        os_memmove(PKEY, G_oxen_state.spend_pub, 32);
+    if (memcmp(subaddr_index, "\0\0\0\0\0\0\0\0", 8) == 0) {
+        memmove(SKEY, G_oxen_state.spend_priv, 32);
+        memmove(PKEY, G_oxen_state.spend_pub, 32);
     } else {
         monero_get_subaddress_secret_key(STMP, G_oxen_state.view_priv, subaddr_index);
         monero_addm(SKEY, STMP, G_oxen_state.spend_priv);
@@ -590,8 +590,8 @@ int oxen_apdu_generate_lns_signature(void) {
 
     oxen_generate_signature(SIGNATURE, G_oxen_state.lns_hash, PKEY, SKEY);
     monero_io_insert(SIGNATURE, 64);
-    os_memset(G_oxen_state.tmp, 0, 128);
-    os_memset(G_oxen_state.lns_hash, 0, 32);
+    memset(G_oxen_state.tmp, 0, 128);
+    memset(G_oxen_state.lns_hash, 0, 32);
 
     return SW_OK;
 }
@@ -675,7 +675,7 @@ int monero_apdu_get_subaddress_secret_key(/*const crypto::secret_key& sec, const
 
     monero_get_subaddress_secret_key(sub_sec, sec, index);
 
-    os_memmove(G_oxen_state.last_get_subaddress_secret_key, sub_sec, 32);
+    memmove(G_oxen_state.last_get_subaddress_secret_key, sub_sec, 32);
     monero_io_insert_encrypt(sub_sec, 32, TYPE_SCALAR);
     return SW_OK;
 }
@@ -734,7 +734,7 @@ int monero_apu_generate_txout_keys(/*size_t tx_version, crypto::secret_key tx_se
             monero_ecmul_G(additional_txkey_pub, additional_txkey_sec);
         }
     } else {
-        os_memset(additional_txkey_pub, 0, 32);
+        memset(additional_txkey_pub, 0, 32);
     }
 
     // derivation

--- a/src/oxen_monero.c
+++ b/src/oxen_monero.c
@@ -139,15 +139,15 @@ unsigned char oxen_wallet_address(char* str_b58, unsigned char* view, unsigned c
     }
     offset = monero_encode_varint(data, ADDR_NETTYPE_MAX_SIZE, prefix);
 
-    os_memmove(data + offset, spend, ADDR_PUBKEY_SIZE);
-    os_memmove(data + offset + ADDR_PUBKEY_SIZE, view, ADDR_PUBKEY_SIZE);
+    memmove(data + offset, spend, ADDR_PUBKEY_SIZE);
+    memmove(data + offset + ADDR_PUBKEY_SIZE, view, ADDR_PUBKEY_SIZE);
     offset += 2*ADDR_PUBKEY_SIZE;
     if (paymentID) {
-        os_memmove(data + offset, paymentID, 8);
+        memmove(data + offset, paymentID, 8);
         offset += ADDR_PAYMENTID_SIZE;
     }
     oxen_keccak_256(&G_oxen_state.keccak, data, offset, G_oxen_state.addr_checksum_hash);
-    os_memmove(data + offset, G_oxen_state.addr_checksum_hash, ADDR_CHECKSUM_SIZE);
+    memmove(data + offset, G_oxen_state.addr_checksum_hash, ADDR_CHECKSUM_SIZE);
     offset += ADDR_CHECKSUM_SIZE;
 
     unsigned char full_block_count = offset / FULL_BLOCK_SIZE;

--- a/src/oxen_open_tx.c
+++ b/src/oxen_open_tx.c
@@ -27,8 +27,8 @@
 /* ---                                                                 --- */
 /* ----------------------------------------------------------------------- */
 void monero_reset_tx(int reset_tx_cnt) {
-    os_memset(G_oxen_state.r, 0, 32);
-    os_memset(G_oxen_state.R, 0, 32);
+    memset(G_oxen_state.r, 0, 32);
+    memset(G_oxen_state.R, 0, 32);
     cx_rng(G_oxen_state.hmac_key, 32);
 
     cx_keccak_init(&G_oxen_state.keccak_alt, 256);
@@ -71,7 +71,7 @@ int monero_apdu_open_tx_cont(void) {
     G_oxen_state.tx_in_progress = 1;
 
 #ifdef DEBUG_HWDEVICE
-    os_memset(G_oxen_state.hmac_key, 0xab, 32);
+    memset(G_oxen_state.hmac_key, 0xab, 32);
 #else
     cx_rng(G_oxen_state.hmac_key, 32);
 #endif

--- a/src/oxen_prehash.c
+++ b/src/oxen_prehash.c
@@ -123,13 +123,13 @@ int monero_apdu_clsag_prehash_update(void) {
                 // First 23, "..", last 23 (so total is 48 = 3 pages on Nano S)
                 G_oxen_state.ux_address[23] = '.';
                 G_oxen_state.ux_address[24] = '.';
-                os_memmove(&G_oxen_state.ux_address[25], &G_oxen_state.ux_address[pos-23], 23);
+                memmove(&G_oxen_state.ux_address[25], &G_oxen_state.ux_address[pos-23], 23);
                 pos = 48;
             } else if (N_oxen_state->truncate_addrs_mode == CONFIRM_ADDRESS_SHORTER) {
                 // 16..14 so that first page gets first [16], last page gets last [..14]
                 G_oxen_state.ux_address[16] = '.';
                 G_oxen_state.ux_address[17] = '.';
-                os_memmove(&G_oxen_state.ux_address[18], &G_oxen_state.ux_address[pos-14], 14);
+                memmove(&G_oxen_state.ux_address[18], &G_oxen_state.ux_address[pos-14], 14);
                 pos = 32;
             }
             G_oxen_state.ux_address[pos] = 0; // null terminate
@@ -147,9 +147,9 @@ int monero_apdu_clsag_prehash_update(void) {
             monero_ecmul_H(aH, v);
             monero_ecadd(aH, kG, aH);
         } else {
-            os_memmove(aH, kG, 32);
+            memmove(aH, kG, 32);
         }
-        if (os_memcmp(C, aH, 32)) {
+        if (memcmp(C, aH, 32)) {
             monero_lock_and_throw(SW_SECURITY_COMMITMENT_CONTROL);
         }
         // update commitment hash control
@@ -158,7 +158,7 @@ int monero_apdu_clsag_prehash_update(void) {
         if ((G_oxen_state.options & IN_OPTION_MORE_COMMAND) == 0) {
             // finalize and check destination hash_control
             oxen_hash_final(&G_oxen_state.sha256, k);
-            if (os_memcmp(k, G_oxen_state.OUTK, 32)) {
+            if (memcmp(k, G_oxen_state.OUTK, 32)) {
                 monero_lock_and_throw(SW_SECURITY_OUTKEYS_CHAIN_CONTROL);
             }
             // finalize commitment hash control
@@ -174,7 +174,7 @@ int monero_apdu_clsag_prehash_update(void) {
             if (!is_change) {
                 if (G_oxen_state.tx_type == TXTYPE_STAKE || G_oxen_state.tx_type == TXTYPE_LNS) {
                     // If this is a stake or LNS tx then the non-change recipient must be ourself.
-                    if (os_memcmp(Aout, G_oxen_state.view_pub, 32) || os_memcmp(Bout, G_oxen_state.spend_pub, 32))
+                    if (memcmp(Aout, G_oxen_state.view_pub, 32) || memcmp(Bout, G_oxen_state.spend_pub, 32))
                         monero_lock_and_throw(SW_SECURITY_INTERNAL);
 
                     ui_menu_stake_validation_display();
@@ -210,7 +210,7 @@ int monero_apdu_clsag_prehash_finalize(void) {
         // Finalize and check commitment hash control
         if (G_oxen_state.tx_sig_mode == TRANSACTION_CREATE_REAL) {
             oxen_hash_final(&G_oxen_state.sha256_alt, H);
-            if (os_memcmp(H, G_oxen_state.commitment_hash, 32)) {
+            if (memcmp(H, G_oxen_state.commitment_hash, 32)) {
                 monero_lock_and_throw(SW_SECURITY_COMMITMENT_CHAIN_CONTROL);
             }
         }
@@ -221,7 +221,7 @@ int monero_apdu_clsag_prehash_finalize(void) {
         monero_io_fetch(proof, 32);
         monero_io_discard(1);
         cx_keccak_init(&G_oxen_state.keccak_alt, 256);
-        if (os_memcmp(message, G_oxen_state.prefixH, 32) != 0) {
+        if (memcmp(message, G_oxen_state.prefixH, 32) != 0) {
             monero_lock_and_throw(SW_SECURITY_PREFIX_HASH);
         }
         oxen_hash_update(&G_oxen_state.keccak_alt, message, 32);

--- a/src/oxen_proof.c
+++ b/src/oxen_proof.c
@@ -55,9 +55,9 @@ int monero_apdu_get_tx_proof(void) {
     // Generate random k
     monero_rng_mod_order(k);
     // tmp = msg
-    os_memmove(G_oxen_state.tmp + 32 * 0, msg, 32);
+    memmove(G_oxen_state.tmp + 32 * 0, msg, 32);
     // tmp = msg || D
-    os_memmove(G_oxen_state.tmp + 32 * 1, D, 32);
+    memmove(G_oxen_state.tmp + 32 * 1, D, 32);
 
     if (G_oxen_state.options & 1) {
         // X = kB
@@ -67,12 +67,12 @@ int monero_apdu_get_tx_proof(void) {
         monero_ecmul_G(XY, k);
     }
     // tmp = msg || D || X
-    os_memmove(G_oxen_state.tmp + 32 * 2, XY, 32);
+    memmove(G_oxen_state.tmp + 32 * 2, XY, 32);
 
     // Y = kA
     monero_ecmul_k(XY, A, k);
     // tmp = msg || D || X || Y
-    os_memmove(G_oxen_state.tmp + 32 * 3, XY, 32);
+    memmove(G_oxen_state.tmp + 32 * 3, XY, 32);
 
 /* Monero V2 proofs (not currently present in Oxen).
  *
@@ -80,13 +80,13 @@ int monero_apdu_get_tx_proof(void) {
 
     oxen_keccak_256(&G_oxen_state.keccak_alt, (unsigned char *)"TXPROOF_V2", 10, sep);
     // tmp = msg || D || X || Y || sep
-    os_memmove(G_oxen_state.tmp + 32 * 4, sep, 32);
+    memmove(G_oxen_state.tmp + 32 * 4, sep, 32);
     // tmp = msg || D || X || Y || sep || R
-    os_memmove(G_oxen_state.tmp + 32 * 5, R, 32);
+    memmove(G_oxen_state.tmp + 32 * 5, R, 32);
     // tmp = msg || D || X || Y || sep || R || A
-    os_memmove(G_oxen_state.tmp + 32 * 6, A, 32);
+    memmove(G_oxen_state.tmp + 32 * 6, A, 32);
     // tmp = msg || D || X || Y || sep || R || B or [0]
-    os_memmove(G_oxen_state.tmp + 32 * 7, B, 32);
+    memmove(G_oxen_state.tmp + 32 * 7, B, 32);
 
     monero_hash_to_scalar(sig_c, &G_oxen_state.tmp[0], 32 * 8);
 */

--- a/src/oxen_types.h
+++ b/src/oxen_types.h
@@ -21,6 +21,10 @@
 #define OXEN_TYPES_H
 
 #include "os_io_seproxyhal.h"
+#include "lcx_blake2.h"
+#include "lcx_sha3.h"
+#include "lcx_sha256.h"
+#include "lcx_aes.h"
 
 #if CX_APILEVEL == 8
 #define PIN_VERIFIED (!0)

--- a/src/oxen_ux_nano.c
+++ b/src/oxen_ux_nano.c
@@ -97,8 +97,8 @@ unsigned int ui_menu_info_action(void) {
 }
 
 void ui_menu_info_display2(const char* line1, const char* line2) {
-    os_memmove(G_oxen_state.ux_info1, line1, sizeof(G_oxen_state.ux_info1)-1);
-    os_memmove(G_oxen_state.ux_info2, line2, sizeof(G_oxen_state.ux_info2)-1);
+    memmove(G_oxen_state.ux_info1, line1, sizeof(G_oxen_state.ux_info1)-1);
+    memmove(G_oxen_state.ux_info2, line2, sizeof(G_oxen_state.ux_info2)-1);
     G_oxen_state.ux_info1[sizeof(G_oxen_state.ux_info1)-1] = 0;
     G_oxen_state.ux_info2[sizeof(G_oxen_state.ux_info2)-1] = 0;
     ux_flow_init(0, ux_flow_info, NULL);
@@ -117,7 +117,7 @@ static const char* processing_tx(void) {
 
 void ui_menu_opentx_display(unsigned char final_step) {
     unsigned char page;
-    os_memmove(G_oxen_state.ux_info1, processing_tx(), sizeof(G_oxen_state.ux_info1)-1);
+    memmove(G_oxen_state.ux_info1, processing_tx(), sizeof(G_oxen_state.ux_info1)-1);
     G_oxen_state.ux_info1[sizeof(G_oxen_state.ux_info1)-1] = 0;
 
     page = G_oxen_state.tx_cnt % 3;
@@ -293,7 +293,7 @@ unsigned int ui_menu_export_viewkey_action(unsigned int value) {
     unsigned char x[32];
 
     monero_io_discard(0);
-    os_memset(x, 0, 32);
+    memset(x, 0, 32);
     sw = SW_OK;
     if (value & 0x10000) { // remember
         value &= ~0x10000;
@@ -617,24 +617,24 @@ void ui_menu_pubaddr_action(void) {
  */
 void ui_menu_any_pubaddr_display(unsigned char* pub_view, unsigned char* pub_spend,
                                  unsigned char is_subbadress, unsigned char* paymentID) {
-    os_memset(G_oxen_state.ux_address, 0, sizeof(G_oxen_state.ux_address));
-    os_memset(G_oxen_state.ux_addr_type, 0, sizeof(G_oxen_state.ux_addr_type));
-    os_memset(G_oxen_state.ux_addr_info, 0, sizeof(G_oxen_state.ux_addr_info));
+    memset(G_oxen_state.ux_address, 0, sizeof(G_oxen_state.ux_address));
+    memset(G_oxen_state.ux_addr_type, 0, sizeof(G_oxen_state.ux_addr_type));
+    memset(G_oxen_state.ux_addr_info, 0, sizeof(G_oxen_state.ux_addr_info));
 
     switch (G_oxen_state.disp_addr_mode) {
         case 0:
         case DISP_MAIN:
-            os_memmove(G_oxen_state.ux_addr_type, "Regular address", 15);
+            memmove(G_oxen_state.ux_addr_type, "Regular address", 15);
             if (N_oxen_state->network_id == MAINNET)
-                os_memmove(G_oxen_state.ux_addr_info, "(mainnet)", 9);
+                memmove(G_oxen_state.ux_addr_info, "(mainnet)", 9);
             else if (N_oxen_state->network_id == TESTNET)
-                os_memmove(G_oxen_state.ux_addr_info, "(testnet)", 9);
+                memmove(G_oxen_state.ux_addr_info, "(testnet)", 9);
             else if (N_oxen_state->network_id == DEVNET)
-                os_memmove(G_oxen_state.ux_addr_info, "(devnet)", 8);
+                memmove(G_oxen_state.ux_addr_info, "(devnet)", 8);
             break;
 
         case DISP_SUB:
-            os_memmove(G_oxen_state.ux_addr_type, "Subaddress", 10);
+            memmove(G_oxen_state.ux_addr_type, "Subaddress", 10);
             // Copy these out because they are in a union with the ux_addr_info string
             unsigned int M = G_oxen_state.disp_addr_M;
             unsigned int m = G_oxen_state.disp_addr_m;
@@ -642,10 +642,10 @@ void ui_menu_any_pubaddr_display(unsigned char* pub_view, unsigned char* pub_spe
             break;
 
         case DISP_INTEGRATED:
-            os_memmove(G_oxen_state.ux_addr_type, "Integr. address", 15);
+            memmove(G_oxen_state.ux_addr_type, "Integr. address", 15);
             // Copy the payment id into place *first*, before the label, because it overlaps with ux_addr_info
-            os_memmove(G_oxen_state.ux_addr_info + 9, G_oxen_state.payment_id, 16);
-            os_memmove(G_oxen_state.ux_addr_info, "Pay. ID: ", 9);
+            memmove(G_oxen_state.ux_addr_info + 9, G_oxen_state.payment_id, 16);
+            memmove(G_oxen_state.ux_addr_info, "Pay. ID: ", 9);
             break;
     }
 

--- a/src/oxen_vars.h
+++ b/src/oxen_vars.h
@@ -21,6 +21,7 @@
 #define OXEN_VARS_H
 
 #include "os.h"
+#include "ux.h"
 #include "cx.h"
 #include "os_io_seproxyhal.h"
 #include "oxen_types.h"


### PR DESCRIPTION
Adds a few now-required headers, and fixes a bunch of now-deprecated calls.