### PR TITLE
Switch to nanox 2.0.0 sdk

### DIFF
--- a/nanox/Makefile
+++ b/nanox/Makefile
@@ -30,21 +30,15 @@ ifeq ($(BOLOS_SDK),)
 $(error Environment variable BOLOS_SDK is not set)
 endif
 
-# Respect a user-provided SYSROOT, but don't respect the SDK Makefile.defines one which does the
-# wrong thing with the debian package arm-none-eabi compiler (appending -I/usr/include, which is
-# completely wrong)
-ifneq ($(SYSROOT),)
-else ifneq ("","$(wildcard /usr/lib/arm-none-eabi)")
-	override SYSROOT := /usr/lib/arm-none-eabi
-endif
-$(info SYSROOT=$(SYSROOT))
-
 include $(BOLOS_SDK)/Makefile.defines
 
 include ../Makefile.oxen
 
 CFLAGS += -Oz -I$(shell pwd)/src
 LDFLAGS += -Oz
+
+# Work around buggy Makefile.defines not setting this:
+AFLAGS += --target=armv6m-none-eabi
 
 ################
 # Default rule #

--- a/src/oxen_crypto.c
+++ b/src/oxen_crypto.c
@@ -24,19 +24,6 @@
 #include "oxen_api.h"
 #include "oxen_vars.h"
 
-#if defined(TARGET_NANOX)
-// The nanos SDK-2.0 deprecated these (because they were misnamed), but as of this writing NANOX
-// only has the old names.  That will probably change at some point but for now provide an alias
-__attribute__((always_inline))
-void cx_edwards_compress_point(cx_curve_t curve, unsigned char *P PLENGTH(P_len), unsigned int P_len) {
-    cx_edward_compress_point(curve, P, P_len);
-}
-__attribute__((always_inline))
-void cx_edwards_decompress_point(cx_curve_t curve, unsigned char *P PLENGTH(P_len), unsigned int P_len) {
-    cx_edward_decompress_point(curve, P, P_len);
-}
-#endif
-
 /* ----------------------------------------------------------------------- */
 /* ---                                                                 --- */
 /* ----------------------------------------------------------------------- */

--- a/src/oxen_main.c
+++ b/src/oxen_main.c
@@ -28,9 +28,6 @@
 #include "glyphs.h"
 
 #include "ux.h"
-#ifdef TARGET_NANOX
-#include "balenos_ble.h"
-#endif
 
 /* ----------------------------------------------------------------------- */
 /* ---                            Application Entry                    --- */


### PR DESCRIPTION
This makes it compile.

However speculos segfaults (in keccak initialization) on all versions of the nanox (and not just for us, but in app-monero too), so I have no idea if it actually works.